### PR TITLE
Set iconifiedByDefault to false

### DIFF
--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -18,6 +18,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/value_10dp"
+        app:iconifiedByDefault="false"
         app:queryHint="@string/discover_restaurants" />
 
     <androidx.core.widget.NestedScrollView


### PR DESCRIPTION
### Description
- Added iconifiedByDefault and set it false. Before that in the Search fragment, the Search View is brought into focus only when we tap on the icon, now no matter where the user clicks the search view will be brought to focus.

resolves #42 

Please ensure the following and put a check accordingly

- [x] My code doesn't break/affect any unrelated part of the codebase

- [ ] Squashed multiple commits (_if irrelevant_) into one commit
